### PR TITLE
Inital GA tracking set up

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# Front-End
-added development branch

--- a/music-app/package.json
+++ b/music-app/package.json
@@ -9,6 +9,7 @@
     "jsonwebtoken": "^8.5.1",
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
+    "react-ga": "^2.6.0",
     "react-redux": "^7.1.0",
     "react-router": "^5.0.1",
     "react-router-dom": "^5.0.1",

--- a/music-app/src/App.js
+++ b/music-app/src/App.js
@@ -1,15 +1,26 @@
 import React, { Component } from 'react';
 import './App.css';
 import ApiRunner from './components/ApiRunner';
-import Auth from './components/Auth'; 
-import { BrowserRouter as Router, Route} from 'react-router-dom'
+import Auth from './components/Auth';
+import { BrowserRouter as Router, Route } from 'react-router-dom';
+import ReactGA from 'react-ga';
+import { createBrowserHistory } from 'history';
+
+const history = createBrowserHistory();
+const trackingId = 'UA-145979080-2';
+ReactGA.initialize(trackingId);
+
+history.listen(location => {
+  ReactGA.set({ page: location.pathname }); // update the user's current page
+  ReactGA.pageview(location.pathname); // Record a pageview for the given page
+});
 
 class App extends Component {
   render() {
     return (
-      <Router>
+      <Router history={history}>
         <div className='App'>Hello World!</div>
-        <Route exact path='/' component ={Auth} />
+        <Route exact path='/' component={Auth} />
         <ApiRunner />
       </Router>
     );

--- a/music-app/yarn.lock
+++ b/music-app/yarn.lock
@@ -8369,6 +8369,11 @@ react-error-overlay@^6.0.1:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.1.tgz#b8d3cf9bb991c02883225c48044cb3ee20413e0f"
   integrity sha512-V9yoTr6MeZXPPd4nV/05eCBvGH9cGzc52FN8fs0O0TVQ3HYYf1n7EgZVtHbldRq5xU9zEzoXIITjYNIfxDDdUw==
 
+react-ga@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/react-ga/-/react-ga-2.6.0.tgz#c3fe830ead2ad25117e1d33280d9698de9b28496"
+  integrity sha512-GWHBWZDFjDGMkIk1LzroIn0mNTygKw3adXuqvGvheFZvlbpqMPbHsQsTdQBIxRRdXGQM/Zq+dQLRPKbwIHMTaw==
+
 react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.9.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.9.0.tgz#21ca9561399aad0ff1a7701c01683e8ca981edcb"


### PR DESCRIPTION
In order to test, must be deployed to development. 

Required Dependencies: 
https://www.npmjs.com/package/react-ga

Currently set to track pageviews.