### PR TITLE
Added Spotify Premium Check

### DIFF
--- a/music-app/src/App.js
+++ b/music-app/src/App.js
@@ -6,8 +6,9 @@ import LikedSongs from './components/LikedSongs';
 import { BrowserRouter as Router, Route } from 'react-router-dom';
 import ReactGA from 'react-ga';
 import { createBrowserHistory } from 'history';
-import Helloworld from './components/Helloworld';
 import { MixpanelConsumer } from 'react-mixpanel';
+import Helloworld from './components/Helloworld';
+import Info from './components/Info';
 
 const history = createBrowserHistory();
 
@@ -29,8 +30,9 @@ class App extends Component {
           path='/dashboard'
           render={props => <LikedSongs {...props} />}
         />
-        <Route exact path='/helloworld' component={Helloworld} />
         <Route exact path='/' render={props => <Auth {...props} />} />
+        <Route exact path='/helloworld' component={Helloworld}/>
+        <Route exact path='/info' render={props => <Info {...props} />} />
       </Router>
     );
   }

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -108,3 +108,33 @@ export const getTrackInfo = id => dispatch => {
       });
     });
 };
+
+export const GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FETCHING = 'GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FETCHING';
+export const GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_SUCCESS = 'GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_SUCCESS';
+export const GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE = 'GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE';
+
+export const getSpotifyAccountDetails = () => dispatch => {
+  dispatch({
+    type: GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FETCHING,
+  });
+
+  var config = {
+    headers: { Authorization: 'Bearer ' + localStorage.getItem('token') },
+  };
+
+  axios
+    .get(`https://api.spotify.com/v1/me`, config)
+    .then(res => {
+      if (!('product' in res.data)) {res.data.product = 'unprovided'}
+      dispatch({
+        type: GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_SUCCESS,
+        payload: res.data,
+      });
+    })
+    .catch(err => {
+      dispatch({
+        type: GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE,
+        payload: err,
+      });
+    });
+};

--- a/music-app/src/analytics/Mixpanel.js
+++ b/music-app/src/analytics/Mixpanel.js
@@ -1,4 +1,4 @@
-import mixpanel from 'mixpanel-browser';
+/* import mixpanel from 'mixpanel-browser';
 
 // Declare mixpanel tracking ID
 mixpanel.init('d94aefc540b96a9d3f4fb06be52a83fd');
@@ -26,3 +26,4 @@ let actions = {
 
 // Export logic to be used inside components we wish to track
 export let Mixpanel = actions;
+ */

--- a/music-app/src/components/Auth.js
+++ b/music-app/src/components/Auth.js
@@ -34,14 +34,11 @@ export class Auth extends Component {
       this.props.history.push('/dashboard');
     }
   }
-
   render() {
     return (
       <div>
         <a
-          href={`${authEndpoint}?client_id=${clientId}&redirect_uri=${redirectUri}&scope=${scopes.join(
-            '%20',
-          )}&response_type=token&show_dialog=true`}>
+          href={`${authEndpoint}?client_id=${clientId}&redirect_uri=${redirectUri}&scope=${encodeURIComponent('user-read-private user-read-email')}&response_type=token&show_dialog=true`}>
           Login
         </a>
       </div>

--- a/music-app/src/components/Info.js
+++ b/music-app/src/components/Info.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { Mixpanel } from '../analytics/Mixpanel';
+
+export class Info extends React.Component {
+
+  render() {
+    return (
+      <div>
+        <p style={{color: "red"}}>To use this service a premium Spotify account is required. Please make sure to granted access to the user-read-private scope during login.</p>
+      </div>
+    );
+  }
+}
+
+export default Info;

--- a/music-app/src/components/LikedSongs.js
+++ b/music-app/src/components/LikedSongs.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import Song from './Song.js';
-import { getlikedSongs, getUsers } from '../actions';
-// import { Mixpanel } from '../analytics/Mixpanel';
+import { getlikedSongs, getUsers, getSpotifyAccountDetails } from '../actions';
+import { Mixpanel } from '../analytics/Mixpanel';
 
 class LikedSongs extends React.Component {
   componentDidMount() {
@@ -11,6 +11,8 @@ class LikedSongs extends React.Component {
     // this.props.mixpanel.track('Spotify Login'); // Removed temp tracking
 
     // Example tracking once implemented
+    this.props.getSpotifyAccountDetails();
+/*     Mixpanel.track('Spotify Login'); */
 
     // // Mixpanel Tracking
     // Mixpanel.identify(this.props.user.display_name);
@@ -30,20 +32,24 @@ class LikedSongs extends React.Component {
   render() {
     if (this.props.fetchingLikedSongs) {
       return <h1>Loading...</h1>;
+    } else if(this.props.spotifyUser.product && this.props.fetchingSpotifyUser === false && this.props.spotifyUser.product !== 'premium') {
+      this.props.history.push('/info')
     }
     return (
-      <div>
+      <div >
         <button onClick={e => this.logout(e)}>Logout</button>
         <div>
           <h1>Liked Songs Dashboard</h1>
           {this.props.songs.map(song => (
-            <Song song={song} id={song.track.id} />
+            <Song song={song} id={song.track.id} key={song.track.id}/>
           ))}
         </div>
         <div>
           <h1>Users</h1>
           {this.props.users.map(user => (
+            <div>
             <p>{user.display_name}</p>
+            </div>
           ))}
         </div>
       </div>
@@ -54,9 +60,11 @@ class LikedSongs extends React.Component {
 const mapStateToProps = state => ({
   songs: state.likedSongsReducer.songs,
   users: state.getUsersReducer.users,
+  spotifyUser: state.getUsersReducer.spotifyUser,
+  fetchingSpotifyUser: state.getUsersReducer.fetchingSpotifyUser
 });
 
 export default connect(
   mapStateToProps,
-  { getlikedSongs, getUsers },
+  { getlikedSongs, getUsers, getSpotifyAccountDetails },
 )(LikedSongs);

--- a/music-app/src/reducers/usersReducer.js
+++ b/music-app/src/reducers/usersReducer.js
@@ -2,12 +2,18 @@ import {
   GET_USERS_FETCHING,
   GET_USERS_SUCCESS,
   GET_USERS_FAILURE,
+  GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FETCHING,
+  GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_SUCCESS,
+  GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE
 } from '../actions';
 
 const initialState = {
   users: [],
   fetchingUsers: false,
   fetchingUsersError: '',
+  spotifyUser: [],
+  fetchingSpotifyUser: false,
+  fetchingSpotifyUserError: '',
 };
 
 const getUsersReducer = (state = initialState, action) => {
@@ -30,6 +36,25 @@ const getUsersReducer = (state = initialState, action) => {
         ...state,
         fetchingUsers: false,
         fetchingUsersError: action.payload,
+      };
+    case GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FETCHING:
+      return {
+        ...state,
+        fetchingSpotifyUser: true,
+        fetchingSpotifyUserError: '',
+      };
+    case GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_SUCCESS:
+      return {
+        ...state,
+        spotifyUser: action.payload,
+        fetchingSpotifyUser: false,
+        fetchingSpotifyUserError: '',
+      };
+    case GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE:
+      return {
+        ...state,
+        fetchingSpotifyUser: false,
+        fetchingSpotifyUserError: action.payload,
       };
     default:
       return state;


### PR DESCRIPTION
To add the check for the premium plan of a Spotify user I had to manipulate the scope access rights of our Spotify Auth. Now we are asking for more permissions and are able to read subscriptions plans of users. I have added some logic into the axios action creator function to prevent a weird API response not having a "product" attached to it by enforcing {product: "unprovided"} for these. Other then that I have created a new redirect for non premium users.


Co-authored-by: Daniel Starling <danielstarling4@gmail.com>