### PR TITLE
Patch feature branch create and get playlist

### DIFF
--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -45,6 +45,7 @@ export const getCurrentUser = spotifyId => dispatch => {
       });
     })
     .catch(err => {
+      console.log('GET CURRENT FAIL spotify', spotifyId);
       dispatch({
         type: GET_LOGGED_IN_FAILURE,
         payload: err,
@@ -213,12 +214,14 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
       }
     })
     .catch(err => {
+      let count = 0;
+      count++;
       if (err.message === 'Request failed with status code 404') {
         axios
           .post(`${url}v1/users/register`, {
             email: spotifyUser.email,
             spotify_user_id: spotifyUser.id,
-            user_spotify_api_key: localStorage.getItem('token'),
+            user_spotify_api_key: 'mocked' + count,
             date_of_birth: '2019-07-29',
             spotify_product_type: spotifyUser.product,
             display_name: spotifyUser.display_name,
@@ -227,11 +230,13 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
             spotify_playlist_id: null,
           })
           .then(res => {
+            console.log('POST PERSIST SUCCESS');
             /* dispatch({ type: PERSIST_USER_SUCCESS, payload: res.data }); */
           })
           .catch(err => {
             /* dispatch({ type: PERSIST_USER_SUCCESS, payload: err }); */
           });
+        console.log('inside err persist', spotifyUser);
       }
       /* dispatch({ type: PERSIST_USER_SUCCESS, payload: err }); */
     });

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -193,6 +193,7 @@ export const persistUser = spotifyUser => dispatch => {
             display_name: res.data.display_name,
             country: res.data.country,
             profile_image_url: res.data.profile_image_url,
+            spotify_playlist_id: playListId,
           })
           .then(res => {
             /*  dispatch({ type: PERSIST_USER_SUCCESS, payload: res.data }); */

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -175,7 +175,7 @@ export const PERSIST_USER_FETCHING = 'GET_CURRENT_SONG_FETCHING';
 export const PERSIST_USER_SUCCESS = 'GET_CURRENT_SONG_SUCCESS';
 export const PERSIST_USER_FAILURE = 'GET_CURRENT_SONG_FAILURE';
 
-export const persistUser = spotifyUser => dispatch => {
+export const persistUser = (spotifyUser, playlistId) => dispatch => {
   dispatch({
     type: PERSIST_USER_FETCHING,
   });
@@ -193,7 +193,7 @@ export const persistUser = spotifyUser => dispatch => {
             display_name: res.data.display_name,
             country: res.data.country,
             profile_image_url: res.data.profile_image_url,
-            spotify_playlist_id: playListId,
+            spotify_playlist_id: playlistId,
           })
           .then(res => {
             /*  dispatch({ type: PERSIST_USER_SUCCESS, payload: res.data }); */
@@ -321,6 +321,11 @@ export const createPlaylist = spotifyId => dispatch => {
       playlistName,
       config,
     )
+    //   console.log('CREATE PLAYLIST ACTION RES PAYLOAD', res.data);
+    //   axios.put(`${url}v1/users/spotify/${res.data.owner.id}`, {
+    //     spotify_playlist_id: res.data.id,
+    //   });
+
     .then(res => {
       dispatch({
         type: CREATE_PLAYLIST_SUCCESS,
@@ -334,7 +339,6 @@ export const createPlaylist = spotifyId => dispatch => {
       });
     });
 };
-
 export const GET_PLAYLIST_FETCHING = 'GET_PLAYLIST_FETCHING';
 export const GET_PLAYLIST_SUCCESS = 'GET_PLAYLIST_SUCCESS';
 export const GET_PLAYLIST_FAILURE = 'GET_PLAYLIST_FAILURE';

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -229,7 +229,7 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
             display_name: spotifyUser.display_name,
             country: spotifyUser.country,
             profile_image_url: '',
-            spotify_playlist_id: null,
+            spotify_playlist_id: playlistId,
           })
           .then(res => {
             console.log('POST PERSIST SUCCESS');

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -38,6 +38,7 @@ export const getCurrentUser = spotifyId => dispatch => {
   axios
     .get(`${url}v1/users/spotify/${spotifyId}`)
     .then(res => {
+      console.log('CURRENT USER RESPONSE', res.data);
       dispatch({
         type: GET_LOGGED_IN_SUCCESS,
         payload: res.data,
@@ -176,6 +177,7 @@ export const PERSIST_USER_SUCCESS = 'GET_CURRENT_SONG_SUCCESS';
 export const PERSIST_USER_FAILURE = 'GET_CURRENT_SONG_FAILURE';
 
 export const persistUser = (spotifyUser, playlistId) => dispatch => {
+  console.log('THIS IS WHAT I AM USING', spotifyUser, playlistId);
   dispatch({
     type: PERSIST_USER_FETCHING,
   });
@@ -183,26 +185,30 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
     .get(`${url}v1/users/spotify/${spotifyUser.id}`)
     .then(res => {
       if (res.status === 200) {
+        const user = {
+          id: res.data.id,
+          email: res.data.email,
+          spotify_user_id: res.data.spotify_user_id,
+          user_spotify_api_key: 'mocked',
+          date_of_birth: res.data.date_of_birth,
+          spotify_product_type: res.data.spotify_product_type,
+          display_name: res.data.display_name,
+          country: res.data.country,
+          profile_image_url: res.data.profile_image_url,
+          spotify_playlist_id: playlistId,
+        };
+        console.log('THIS IS MY USER', JSON.stringify(user));
         axios
-          .put(`${url}v1/users/${res.data.id}`, {
-            email: res.data.email,
-            spotify_user_id: res.data.spotify_user_id,
-            user_spotify_api_key: localStorage.getItem('token'),
-            date_of_birth: res.data.date_of_birth,
-            spotify_product_type: res.data.spotify_product_type,
-            display_name: res.data.display_name,
-            country: res.data.country,
-            profile_image_url: res.data.profile_image_url,
-            spotify_playlist_id: playlistId,
-          })
+          .put(`${url}v1/users/${res.data.id}`, user)
           .then(res => {
-            /*  dispatch({ type: PERSIST_USER_SUCCESS, payload: res.data }); */
+            console.log('SUCCESSFULL IT WAS MY MAN', res);
+            dispatch({ type: PERSIST_USER_SUCCESS });
           })
           .catch(err => {
-            /*  dispatch({
+            console.log('BUT WHYYYYY', err);
+            dispatch({
               type: PERSIST_USER_FAILURE,
-              payload: err,
-            }); */
+            });
           });
       }
     })
@@ -218,6 +224,7 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
             display_name: spotifyUser.display_name,
             country: spotifyUser.country,
             profile_image_url: '',
+            spotify_playlist_id: null,
           })
           .then(res => {
             /* dispatch({ type: PERSIST_USER_SUCCESS, payload: res.data }); */

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -190,7 +190,9 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
           id: res.data.id,
           email: res.data.email,
           spotify_user_id: res.data.spotify_user_id,
-          user_spotify_api_key: 'mocked',
+          user_spotify_api_key: Math.floor(
+            Math.random() * 99999999999 + 1,
+          ).toString(),
           date_of_birth: res.data.date_of_birth,
           spotify_product_type: res.data.spotify_product_type,
           display_name: res.data.display_name,
@@ -214,14 +216,14 @@ export const persistUser = (spotifyUser, playlistId) => dispatch => {
       }
     })
     .catch(err => {
-      let count = 0;
-      count++;
       if (err.message === 'Request failed with status code 404') {
         axios
           .post(`${url}v1/users/register`, {
             email: spotifyUser.email,
             spotify_user_id: spotifyUser.id,
-            user_spotify_api_key: 'mocked' + count,
+            user_spotify_api_key: Math.floor(
+              Math.random() * 99999999999 + 1,
+            ).toString(),
             date_of_birth: '2019-07-29',
             spotify_product_type: spotifyUser.product,
             display_name: spotifyUser.display_name,

--- a/music-app/src/actions/index.js
+++ b/music-app/src/actions/index.js
@@ -26,6 +26,31 @@ export const getUsers = () => dispatch => {
     });
 };
 
+export const GET_LOGGED_IN_FETCHING = 'GET_LOGGED_IN_FETCHING';
+export const GET_LOGGED_IN_SUCCESS = 'GET_LOGGED_IN_SUCCESS';
+export const GET_LOGGED_IN_FAILURE = 'GET_LOGGED_IN_FAILURE';
+
+export const getCurrentUser = spotifyId => dispatch => {
+  console.log('GETCURRENTUSER', spotifyId);
+  dispatch({
+    type: GET_LOGGED_IN_FETCHING,
+  });
+  axios
+    .get(`${url}v1/users/spotify/${spotifyId}`)
+    .then(res => {
+      dispatch({
+        type: GET_LOGGED_IN_SUCCESS,
+        payload: res.data,
+      });
+    })
+    .catch(err => {
+      dispatch({
+        type: GET_LOGGED_IN_FAILURE,
+        payload: err,
+      });
+    });
+};
+
 export const GET_LIKEDSONGS_FETCHING = 'GET_LIKEDSONGS_FETCHING';
 export const GET_LIKEDSONGS_SUCCESS = 'GET_LIKEDSONGS_SUCCESS';
 export const GET_LIKEDSONGS_FAILURE = 'GET_LIKEDSONGS_FAILURE';

--- a/music-app/src/reducers/createPlaylistReducer.js
+++ b/music-app/src/reducers/createPlaylistReducer.js
@@ -6,6 +6,7 @@ import {
 
 const initialState = {
   playlistId: null,
+  fetchingPlaylist: false,
   error: '',
 };
 
@@ -14,16 +15,19 @@ const createPlaylistReducer = (state = initialState, action) => {
     case CREATE_PLAYLIST_FETCHING:
       return {
         ...state,
+        fetchingPlaylist: true,
       };
     case CREATE_PLAYLIST_SUCCESS:
       return {
         ...state,
         playlistId: action.payload.id,
+        fetchingPlaylist: false,
       };
     case CREATE_PLAYLIST_FAILURE:
       return {
         ...state,
         error: action.payload,
+        fetchingPlaylist: false,
       };
     default:
       return state;

--- a/music-app/src/reducers/createPlaylistReducer.js
+++ b/music-app/src/reducers/createPlaylistReducer.js
@@ -5,7 +5,7 @@ import {
 } from '../actions';
 
 const initialState = {
-  playlistId: '',
+  playlistId: null,
   error: '',
 };
 

--- a/music-app/src/reducers/getCurrentUserReducer.js
+++ b/music-app/src/reducers/getCurrentUserReducer.js
@@ -1,0 +1,36 @@
+import {
+  GET_LOGGED_IN_FETCHING,
+  GET_LOGGED_IN_SUCCESS,
+  GET_LOGGED_IN_FAILURE,
+} from '../actions';
+
+const initialState = {
+  currentUser: [],
+  currentUserFetching: false,
+  error: '',
+};
+
+const getCurrentUserReducer = (state = initialState, action) => {
+  switch (action.type) {
+    case GET_LOGGED_IN_FETCHING:
+      return {
+        ...state,
+        currentUserFetching: true,
+      };
+    case GET_LOGGED_IN_SUCCESS:
+      return {
+        ...state,
+        currentUser: action.payload,
+        currentUserFetching: false,
+      };
+    case GET_LOGGED_IN_FAILURE:
+      return {
+        ...state,
+        error: '',
+      };
+    default:
+      return state;
+  }
+};
+
+export default getCurrentUserReducer;

--- a/music-app/src/reducers/getCurrentUserReducer.js
+++ b/music-app/src/reducers/getCurrentUserReducer.js
@@ -5,7 +5,7 @@ import {
 } from '../actions';
 
 const initialState = {
-  currentUser: [],
+  currentUser: {},
   currentUserFetching: false,
   error: '',
 };

--- a/music-app/src/reducers/index.js
+++ b/music-app/src/reducers/index.js
@@ -6,6 +6,7 @@ import currentSongReducer from './getCurrentSongReducer';
 import queueReducer from './queueReducer';
 import createPlaylistReducer from './createPlaylistReducer';
 import getPlaylistReducer from './getPlaylistReducer';
+import getCurrentUserReducer from './getCurrentUserReducer';
 
 export default combineReducers({
   getUsersReducer,
@@ -15,4 +16,5 @@ export default combineReducers({
   queueReducer,
   createPlaylistReducer,
   getPlaylistReducer,
+  getCurrentUserReducer,
 });

--- a/music-app/src/reducers/usersReducer.js
+++ b/music-app/src/reducers/usersReducer.js
@@ -4,7 +4,10 @@ import {
   GET_USERS_FAILURE,
   GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FETCHING,
   GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_SUCCESS,
-  GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE
+  GET_SPOTIFY_PRIVATE_ACCOUNT_DETAILS_FAILURE,
+  PERSIST_USER_FETCHING,
+  PERSIST_USER_SUCCESS,
+  PERSIST_USER_FAILURE,
 } from '../actions';
 
 const initialState = {
@@ -55,6 +58,18 @@ const getUsersReducer = (state = initialState, action) => {
         ...state,
         fetchingSpotifyUser: false,
         fetchingSpotifyUserError: action.payload,
+      };
+    case PERSIST_USER_FETCHING:
+      return {
+        ...state,
+      };
+    case PERSIST_USER_SUCCESS:
+      return {
+        ...state,
+      };
+    case PERSIST_USER_FAILURE:
+      return {
+        ...state,
       };
     default:
       return state;

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -122,6 +122,7 @@ class Dashboard extends React.Component {
     // If it has - do nothing
 
     if (this.state.userDataFetching === false && this.props.spotifyUser.id) {
+      console.log('FIRED OFF');
       this.props.getCurrentUser(this.props.spotifyUser.id);
       this.setState({
         userDataFetching: true,
@@ -131,14 +132,23 @@ class Dashboard extends React.Component {
     // Check user obj for playlist ID
     if (
       !this.state.playlistCreated &&
-      this.props.spotifyUser.id &&
-      !this.props.currentUser.spotify_playlist_id
+      /* this.props.spotifyUser.id && */
+      !this.props.fetchingCreatePlaylist &&
+      this.props.playlistId === null
     ) {
       console.log('INSIDE BIG BRAIN FUNCTION', this.props);
       this.props.createPlaylist(this.props.spotifyUser.id);
+    }
+
+    if (this.props.playlistId && !this.state.playlistCreated) {
+      this.props.persistUser(this.props.spotifyUser, this.props.playlistId);
+      console.log('DID IT HAPPEN?', this.props.playlistId);
       this.setState({
         playlistCreated: true,
       });
+      setTimeout(() => {
+        this.props.getCurrentUser(this.props.spotifyUser.id);
+      }, 4000);
     }
 
     // if no have then run createplaylist
@@ -204,7 +214,8 @@ class Dashboard extends React.Component {
     // console.log('getSpotifyAccountDetails ! _ 0', this.props);
 
     console.log('What is this', this.props);
-    console.log('current USER OBJ ______', this.props.currentUser);
+    console.log('HERE I AM ', this.props.playlistId);
+    console.log('DAY AFTER TOMORROW', this.props.currentUser);
 
     return (
       <div className='dashboard'>
@@ -301,6 +312,7 @@ const mapStateToProps = state => ({
   ds_songs: state.queueReducer.ds_songs,
   several_tracks: state.queueReducer.several_tracks,
   playlistId: state.createPlaylistReducer.playlistId,
+  fetchingCreatePlaylist: state.createPlaylistReducer.fetchingPlaylist,
 });
 
 export default connect(

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -136,7 +136,11 @@ class Dashboard extends React.Component {
         userDataFetching: true,
       });
     }
-
+    console.log('FETCHINGCREATE PLAYLIST', !this.props.fetchingCreatePlaylist);
+    console.log(
+      'CURRENTUSER SPOT_PLAY',
+      !this.props.currentUser.spotify_playlist_id,
+    );
     // Check user obj for playlist ID
     setTimeout(() => {
       if (
@@ -144,7 +148,7 @@ class Dashboard extends React.Component {
         /* this.props.spotifyUser.id && */
         !this.props.fetchingCreatePlaylist &&
         // this.props.playlistId === null &&
-        this.props.currentUser.spotify_playlist_id === null
+        !this.props.currentUser.spotify_playlist_id
       ) {
         console.log('INSIDE BIG BRAIN FUNCTION', this.props);
         this.props.createPlaylist(this.props.spotifyUser.id);

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -15,6 +15,7 @@ import {
   postDSSong,
   getSeveralTracks,
   createPlaylist,
+  getCurrentUser,
 } from '../actions';
 
 import LikedSongs from '../components/dashboard/LikedSongs';
@@ -100,6 +101,7 @@ class Dashboard extends React.Component {
     ],
     popout: false,
     playlistCreated: false,
+    userDataFetching: false,
   };
 
   componentDidMount() {
@@ -112,9 +114,24 @@ class Dashboard extends React.Component {
     // console.log('Previous Props', prevProps);
     // console.log('Current Props', this.props);
 
+    // Check to see if a MM playlist has been saved to BE user
+    // -- in order to do this pull in user data from BE specifically playlist.id
+
+    // If not - Create a playlist and save to BE user table
+    // If it has - do nothing
+
+    if (this.state.userDataFetching === false && this.props.spotifyUser.id) {
+      this.props.getCurrentUser(this.props.spotifyUser.id);
+      this.setState({
+        userDataFetching: true,
+      });
+    }
+
+    // if (this.props.currentUser.playlist)
     if (this.state.playlistCreated === false && this.props.spotifyUser.id) {
       console.log('This.state', this.state.playlistCreated);
       console.log('This.ID', this.props.spotifyUser.id);
+      console.log('dashboard props', this.props);
 
       this.props.persistUser(this.props.spotifyUser);
       this.props.createPlaylist(this.props.spotifyUser.id);
@@ -141,6 +158,7 @@ class Dashboard extends React.Component {
     localStorage.removeItem('token');
     this.props.history.push('/logout');
   };
+
   checkPremiumUser = () => {
     return this.props.spotifyUser.product &&
       this.props.fetchingSpotifyUser === false &&
@@ -161,7 +179,10 @@ class Dashboard extends React.Component {
       this.props.history.push('/info');
     }
 
+    // console.log('getSpotifyAccountDetails ! _ 0', this.props);
+
     console.log('What is this', this.props);
+    console.log('current USER OBJ ______', this.props.currentUser);
 
     return (
       <div className='dashboard'>
@@ -253,6 +274,7 @@ class Dashboard extends React.Component {
 
 const mapStateToProps = state => ({
   spotifyUser: state.getUsersReducer.spotifyUser,
+  currentUser: state.getCurrentUserReducer.currentUser,
   fetchingSpotifyUser: state.getUsersReducer.fetchingSpotifyUser,
   ds_songs: state.queueReducer.ds_songs,
   several_tracks: state.queueReducer.several_tracks,
@@ -269,5 +291,6 @@ export default connect(
     postDSSong,
     getSeveralTracks,
     createPlaylist,
+    getCurrentUser,
   },
 )(Dashboard);

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -108,6 +108,7 @@ class Dashboard extends React.Component {
   componentDidMount() {
     this.props.getSpotifyAccountDetails();
     this.props.getCurrentUser(this.props.spotifyUser.id);
+    // this.props.persistUser(this.props.spotifyUser);
     this.props.getlikedSongs();
   }
 
@@ -123,6 +124,11 @@ class Dashboard extends React.Component {
     // If not - Create a playlist and save to BE user table
     // If it has - do nothing
 
+    if (this.props.spotifyUser) {
+      console.log('I EXIST SPOTID', this.props.spotifyUser);
+      this.props.persistUser(this.props.spotifyUser);
+    }
+
     if (this.state.userDataFetching === false && this.props.spotifyUser.id) {
       console.log('FIRED OFF');
       this.props.getCurrentUser(this.props.spotifyUser.id);
@@ -137,13 +143,13 @@ class Dashboard extends React.Component {
         !this.state.playlistCreated &&
         /* this.props.spotifyUser.id && */
         !this.props.fetchingCreatePlaylist &&
-        this.props.playlistId === null &&
+        // this.props.playlistId === null &&
         this.props.currentUser.spotify_playlist_id === null
       ) {
         console.log('INSIDE BIG BRAIN FUNCTION', this.props);
         this.props.createPlaylist(this.props.spotifyUser.id);
       }
-    }, 5000);
+    }, 4000);
 
     if (this.props.playlistId && !this.state.playlistCreated) {
       this.props.persistUser(this.props.spotifyUser, this.props.playlistId);
@@ -153,7 +159,7 @@ class Dashboard extends React.Component {
       });
       setTimeout(() => {
         this.props.getCurrentUser(this.props.spotifyUser.id);
-      }, 4000);
+      }, 5000);
     }
 
     // if no have then run createplaylist

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -127,14 +127,15 @@ class Dashboard extends React.Component {
       });
     }
 
-    // if (this.props.currentUser.playlist)
-    if (this.state.playlistCreated === false && this.props.spotifyUser.id) {
-      console.log('This.state', this.state.playlistCreated);
-      console.log('This.ID', this.props.spotifyUser.id);
-      console.log('dashboard props', this.props);
-
+    if (
+      !this.props.currentUser.spotify_playlist_id &&
+      this.state.playlistCreated === false &&
+      this.props.spotifyUser.id
+    ) {
+      console.log('INSIDE BIG BRAIN FUNCTION', this.props);
       this.props.persistUser(this.props.spotifyUser);
       this.props.createPlaylist(this.props.spotifyUser.id);
+      this.props.persistUser(this.props.spotifyUser, 'whatever');
       this.setState({
         playlistCreated: true,
       });

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -107,7 +107,7 @@ class Dashboard extends React.Component {
 
   componentDidMount() {
     this.props.getSpotifyAccountDetails();
-    this.props.getCurrentUser(this.props.spotifyUser.id);
+    // this.props.getCurrentUser(this.props.spotifyUser.id);
     // this.props.persistUser(this.props.spotifyUser);
     this.props.getlikedSongs();
   }
@@ -124,10 +124,10 @@ class Dashboard extends React.Component {
     // If not - Create a playlist and save to BE user table
     // If it has - do nothing
 
-    if (this.props.spotifyUser) {
-      console.log('I EXIST SPOTID', this.props.spotifyUser);
-      this.props.persistUser(this.props.spotifyUser);
-    }
+    // if (this.props.spotifyUser) {
+    //   console.log('I EXIST SPOTID', this.props.spotifyUser);
+    //   this.props.persistUser(this.props.spotifyUser);
+    // }
 
     if (this.state.userDataFetching === false && this.props.spotifyUser.id) {
       console.log('FIRED OFF');

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -130,15 +130,18 @@ class Dashboard extends React.Component {
     }
 
     // Check user obj for playlist ID
-    if (
-      !this.state.playlistCreated &&
-      /* this.props.spotifyUser.id && */
-      !this.props.fetchingCreatePlaylist &&
-      this.props.playlistId === null
-    ) {
-      console.log('INSIDE BIG BRAIN FUNCTION', this.props);
-      this.props.createPlaylist(this.props.spotifyUser.id);
-    }
+    setTimeout(() => {
+      if (
+        !this.state.playlistCreated &&
+        /* this.props.spotifyUser.id && */
+        !this.props.fetchingCreatePlaylist &&
+        this.props.playlistId === null &&
+        this.props.currentUser.spotify_playlist_id === null
+      ) {
+        console.log('INSIDE BIG BRAIN FUNCTION', this.props);
+        this.props.createPlaylist(this.props.spotifyUser.id);
+      }
+    }, 5000);
 
     if (this.props.playlistId && !this.state.playlistCreated) {
       this.props.persistUser(this.props.spotifyUser, this.props.playlistId);

--- a/music-app/src/views/Dashboard.js
+++ b/music-app/src/views/Dashboard.js
@@ -106,6 +106,7 @@ class Dashboard extends React.Component {
 
   componentDidMount() {
     this.props.getSpotifyAccountDetails();
+    this.props.getCurrentUser(this.props.spotifyUser.id);
   }
 
   componentDidUpdate(prevProps) {
@@ -127,19 +128,39 @@ class Dashboard extends React.Component {
       });
     }
 
+    // Check user obj for playlist ID
     if (
-      !this.props.currentUser.spotify_playlist_id &&
-      this.state.playlistCreated === false &&
-      this.props.spotifyUser.id
+      !this.state.playlistCreated &&
+      this.props.spotifyUser.id &&
+      !this.props.currentUser.spotify_playlist_id
     ) {
       console.log('INSIDE BIG BRAIN FUNCTION', this.props);
-      this.props.persistUser(this.props.spotifyUser);
       this.props.createPlaylist(this.props.spotifyUser.id);
-      this.props.persistUser(this.props.spotifyUser, 'whatever');
       this.setState({
         playlistCreated: true,
       });
     }
+
+    // if no have then run createplaylist
+    // update component state with flag to false
+
+    // save playlist id through persistuser
+
+    //   if (this.props.playlistId) {
+    //     if (
+    //       this.props.spotifyUser.id &&
+    //       // this.props.playlistId &&
+    //       !this.props.currentUser.spotify_playlist_id &&
+    //       ) {
+    //     // this.props.persistUser(this.props.spotifyUser);
+    //     this.props.createPlaylist(this.props.spotifyUser.id);
+    //     this.setState({
+    //       playlistCreated: true,
+    //     });
+    //     console.log('INSIDE BIG BRAIN FUNCTION', this.props);
+    //   }
+    // }
+    console.log('OUTSIDE BIGGER BRAIN FUNCTION', this.props);
   }
 
   openPlaylist() {


### PR DESCRIPTION
We got creating a playlist and persisting it into the database working. On dashboard visit only a new playlist will be created when the database "spotify_database_id" is set to null. Otherwhise a new playlist will be created and the playlist_id persisted into the database. CurrentUser properties now contain the correct spotify_playlist_id. Some of that was achieved through timer that let other api calls load in the background so that they can trigger off with the other data existing.